### PR TITLE
Fixed href typo

### DIFF
--- a/dfp-amp-testing/amp_tests/dfp-exclusion.html
+++ b/dfp-amp-testing/amp_tests/dfp-exclusion.html
@@ -44,7 +44,7 @@
                 <span class="label label-warning">Description</span> <br>
               <hr></hr>
              <p class="text-left"> A test to highlight the DFP exclusion feature by labeling the lineitems. If two lineitems have the same label, then even though both lineitems are eligible to serve on the same page, only one lineitem serves to the page. </p>
-             <div class="label label-info"><a href ="httpdfp-ex://github.com/jasti/amp-ads-testing/blob/master/dfp-amp-testing/amp_tests/dfp-exclusion-demo.html" target="_blank">Click To See Source Code</a></div>
+             <div class="label label-info"><a href ="https://github.com/jasti/amp-ads-testing/blob/master/dfp-amp-testing/amp_tests/dfp-exclusion-demo.html" target="_blank">Click To See Source Code</a></div>
               <br> </br>
 
              <li>  <p class="text-left"> Line item Details <p class="text-left">


### PR DESCRIPTION
Fixed typo in the href for "Click To See Source Code" button on the UI
